### PR TITLE
fix: prevent overflow when swiping past end of feed

### DIFF
--- a/FeedFragment.kt
+++ b/FeedFragment.kt
@@ -65,9 +65,9 @@ class FeedFragment : Fragment() {
     }
     
     private fun nextClip() {
-        current?.let { emitViewEnd(items[currentIndex], it) }
-        current?.let { pool.release(it) }
-        currentIndex = nextIndex() ?: currentIndex
+        val next = nextIndex() ?: return
+        current?.let { emitViewEnd(items[currentIndex], it); pool.release(it) }
+        currentIndex = next
         current = pool.acquire()
         playerView.player = current?.exo()
         current?.play()

--- a/FeedViewController.swift
+++ b/FeedViewController.swift
@@ -46,10 +46,10 @@ final class FeedViewController: UIViewController {
     }
     
     @objc private func nextClip() {
-        guard let c = current else { return }
+        guard let c = current, let next = nextIndex() else { return }
         emitViewEnd(for: items[currentIndex], using: c)
         pool.release(c)
-        currentIndex = nextIndex() ?? currentIndex
+        currentIndex = next
         current = pool.acquire()
         current?.attach(to: videoView)
         current?.onEvent = { [weak self] name, props in self?.handleEvent(name, props) }


### PR DESCRIPTION
## Summary
- avoid releasing current player when no next clip exists on Android feed
- require a valid next clip before advancing in iOS feed controller

## Testing
- `swiftc FeedViewController.swift PlayerKit-iOS.swift` *(fails: no such module 'UIKit')*
- `kotlinc -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a895afc07c832aac5c55a2ab4d54ac